### PR TITLE
Add rack-health.rb to help bundler load rack/health.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rack::Health is a health check interface for rack applications.
 ## Install
 ```ruby
 # Gemfile
-gem 'rack-health', :require => 'rack/health'
+gem 'rack-health'
 ```
 
 ## Basic

--- a/lib/rack-health.rb
+++ b/lib/rack-health.rb
@@ -1,0 +1,1 @@
+require 'rack/health'


### PR DESCRIPTION
### before

``` ruby
gem "rack-health", require: "rack/health"
```
### after

``` ruby
gem "rack-health"
```
### testing

Just confirmed by the following command:

``` sh
# shell-command
$ cd /path/to/rack-health
$ ruby -Ilib -rrack-health -e "p defined?(Rack::Health)"
"constant"
```
